### PR TITLE
Update README: fix Maven coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.brendangoldberg.kotlin-jwt:<latest-version>")
-
+  implementation("com.brendangoldberg:kotlin-jwt:<latest-version>")
 }
-
 ```


### PR DESCRIPTION
A small mistake :)

`com.brendangoldberg.kotlin-jwt`

`com.brendangoldberg:kotlin-jwt`